### PR TITLE
Add caching layer and enhance cache configuration

### DIFF
--- a/.idea/runConfigurations/Development_PostgreSQL.xml
+++ b/.idea/runConfigurations/Development_PostgreSQL.xml
@@ -11,7 +11,7 @@
       <env name="SIMDESK_DB_USERNAME" value="postgres" />
       <env name="SIMDESK_IMPRESSUM_URL" value="https://example.com" />
       <env name="SIMDESK_PRIVACY_URL" value="https://example.com" />
-      <env name="SIMDESK_THEME" value="default" />
+      <env name="SIMDESK_THEME" value="BLACK_AND_WHITE" />
     </envs>
     <option name="HIDE_BANNER" value="true" />
     <module name="simdesk.simdesk-web.main" />

--- a/simdesk-web/build.gradle
+++ b/simdesk-web/build.gradle
@@ -50,8 +50,14 @@ dependencies {
     runtimeOnly "org.xerial:sqlite-jdbc:3.50.3.0"
     implementation "org.flywaydb:flyway-database-postgresql"
 
+    // Caching
+    implementation "com.github.ben-manes.caffeine:caffeine"
+
     // Logging
     implementation "io.logz.logback:logzio-logback-appender:2.4.0"
+
+    // Metrics
+    runtimeOnly "io.micrometer:micrometer-registry-prometheus"
 
     // Apache Commons
     implementation "org.apache.commons:commons-lang3:3.19.0"

--- a/simdesk-web/development/.gitignore
+++ b/simdesk-web/development/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/simdesk-web/development/results/.gitignore
+++ b/simdesk-web/development/results/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/CacheConfiguration.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/CacheConfiguration.java
@@ -1,0 +1,49 @@
+package de.sustineo.simdesk.configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+
+@Configuration
+public class CacheConfiguration {
+    private static final int MAXIMUM_WEIGHT = 50_000;
+
+    @Bean
+    CaffeineCacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(CacheNames.ALL);
+
+        // Define the global builder (applies to all caches unless overridden)
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder()
+                        .maximumWeight(MAXIMUM_WEIGHT)
+                        .weigher(BoundedSizeWeigher.INSTANCE)
+                        .expireAfterWrite(Duration.ofMinutes(15))
+                        .recordStats()
+        );
+
+        return cacheManager;
+    }
+
+    @NullMarked
+    private enum BoundedSizeWeigher implements Weigher<Object, Object> {
+        INSTANCE;
+
+        @Override
+        public int weigh(Object key, Object value) {
+            int weight = switch (value) {
+                case Collection<?> collection -> Math.max(1, collection.size());
+                case Map<?, ?> map -> Math.max(1, map.size());
+                default -> 1;
+            };
+
+            return Math.min(weight, MAXIMUM_WEIGHT / 10);
+        }
+    }
+}

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/CacheNames.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/CacheNames.java
@@ -1,0 +1,31 @@
+package de.sustineo.simdesk.configuration;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CacheNames {
+    public static final String API_KEY = "api-key";
+    public static final String SETTINGS = "settings";
+    public static final String BOPS = "bops";
+    public static final String BOP_PROVIDERS = "bop-providers";
+    public static final String SESSION = "session";
+    public static final String SESSIONS = "sessions";
+    public static final String LAPS_SESSION = "lap-session";
+    public static final String LAPS_DRIVER = "lap-driver";
+    public static final String RANKINGS = "rankings";
+    public static final String LEADERBOARD_LINES = "leaderboard-lines";
+
+    public static final String[] ALL = {
+            API_KEY,
+            SETTINGS,
+            BOPS,
+            BOP_PROVIDERS,
+            SESSION,
+            SESSIONS,
+            LAPS_SESSION,
+            LAPS_DRIVER,
+            RANKINGS,
+            LEADERBOARD_LINES
+    };
+}

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/SecurityConfiguration.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/configuration/SecurityConfiguration.java
@@ -3,6 +3,7 @@ package de.sustineo.simdesk.configuration;
 import com.vaadin.flow.spring.security.NavigationAccessControlConfigurer;
 import com.vaadin.flow.spring.security.VaadinAwareSecurityContextHolderStrategyConfiguration;
 import com.vaadin.flow.spring.security.VaadinSecurityConfigurer;
+import de.sustineo.simdesk.entities.auth.UserRoleEnum;
 import de.sustineo.simdesk.filter.ApiKeyAuthenticationFilter;
 import de.sustineo.simdesk.services.auth.UserService;
 import de.sustineo.simdesk.services.discord.DiscordService;
@@ -43,13 +44,14 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SecurityConfiguration {
     private final String[] PUBLIC_PATHS = {
-            "/public/**",
-            "/assets/**",
-            "/icons/**",
-            "/swagger-ui/**",
-            "/openapi/**",
-            "/ws/**",
-            "/*.png" // Leaflet images
+            "/actuator/health", // Actuator
+            "/public/**",       // Vaadin
+            "/assets/**",       // Vaadin
+            "/icons/**",        // Icons
+            "/swagger-ui/**",   // SpringDoc
+            "/openapi/**",      // SpringDoc
+            "/ws/**",           // WebSockets
+            "/*.png"            // Leaflet images
     };
     private static final String LOGIN_URL = "/login";
     private static final String LOGIN_SUCCESS_URL = "/";
@@ -74,6 +76,7 @@ public class SecurityConfiguration {
                 })
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_PATHS).permitAll()
+                        .requestMatchers("/actuator/**").hasAuthority(UserRoleEnum.ROLE_ADMIN.name())
                 )
                 .addFilterAfter(apiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/controller/DriverController.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/controller/DriverController.java
@@ -65,7 +65,7 @@ public class DriverController {
                 .toList();
 
         if (withLaps) {
-            sessionResponse.forEach(session -> session.setLaps(lapService.getBySessionIdAndDriverId(session.getId(), driverId)));
+            sessionResponse.forEach(session -> session.setLaps(lapService.getBySessionIdAndDriverIds(session.getId(), List.of(driverId))));
         }
 
         return new ServiceResponse<>(HttpStatus.OK, sessionResponse).toResponseEntity();

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/mybatis/mapper/LapMapper.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/mybatis/mapper/LapMapper.java
@@ -26,21 +26,6 @@ public interface LapMapper {
             @Result(property = "valid", column = "valid"),
     })
     @Select("""
-            <script>
-            SELECT lap.*, driver.first_name, driver.last_name, driver.short_name, driver.visibility FROM lap
-            LEFT JOIN driver ON lap.driver_id = driver.driver_id
-            WHERE lap.session_id = #{sessionId} AND lap.driver_id IN
-                <foreach item="item" index="index" collection="driverIds"
-                    open="(" separator="," close=")">
-                      #{item}
-                </foreach>
-            ORDER BY id ASC;
-            </script>
-            """)
-    List<Lap> findBySessionIdAndDriverIds(int sessionId, List<String> driverIds);
-
-    @ResultMap("lapResultMap")
-    @Select("""
             SELECT lap.*, driver.first_name, driver.last_name, driver.short_name, driver.visibility FROM lap
             LEFT JOIN driver ON lap.driver_id = driver.driver_id
             WHERE session_id = #{sessionId}

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/SettingService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/SettingService.java
@@ -1,5 +1,6 @@
 package de.sustineo.simdesk.services;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.entities.Setting;
 import de.sustineo.simdesk.mybatis.mapper.SettingMapper;
 import de.sustineo.simdesk.utils.json.JsonClient;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Service;
 public class SettingService {
     private final SettingMapper settingMapper;
 
-    @Cacheable(value = "settings", key = "#key")
+    @Cacheable(cacheNames = CacheNames.SETTINGS, key = "#key")
     public String get(String key) {
         Setting property = settingMapper.findActive(key);
         if (property == null) {
@@ -23,7 +24,7 @@ public class SettingService {
         return property.getValue();
     }
 
-    @Cacheable(value = "properties", key = "#key")
+    @Cacheable(cacheNames = CacheNames.SETTINGS, key = "#key")
     public <T> T getJson(String key, Class<T> clazz) {
         String value = get(key);
         if (value == null) {
@@ -33,12 +34,12 @@ public class SettingService {
         return JsonClient.fromJson(value, clazz);
     }
 
-    @CacheEvict(value = "settings", key = "#key")
+    @CacheEvict(cacheNames = CacheNames.SETTINGS, key = "#key")
     public void set(String key, String value) {
         settingMapper.update(key, value);
     }
 
-    @CacheEvict(value = "properties", key = "#key")
+    @CacheEvict(cacheNames = CacheNames.SETTINGS, key = "#key")
     public void setJson(String key, Object value) {
         set(key, JsonClient.toJson(value));
     }

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/auth/ApiKeyService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/auth/ApiKeyService.java
@@ -1,12 +1,12 @@
 package de.sustineo.simdesk.services.auth;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.entities.auth.ApiKey;
 import de.sustineo.simdesk.mybatis.mapper.UserApiKeyMapper;
 import de.sustineo.simdesk.mybatis.mapper.UserPermissionMapper;
 import de.sustineo.simdesk.services.IdGenerator;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
@@ -16,56 +16,38 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class ApiKeyService {
-    private static final String CACHE_ACTIVE_API_KEYS = "activeApiKeys";
-
     private final UserApiKeyMapper apiKeyMapper;
     private final UserPermissionMapper userPermissionMapper;
-    private final CacheManager cacheManager;
     private final IdGenerator idGenerator;
 
     public List<ApiKey> getByUserId(Integer userId) {
         return apiKeyMapper.findByUserId(userId);
     }
 
-    @Cacheable(cacheNames = CACHE_ACTIVE_API_KEYS)
-    public Optional<ApiKey> getActiveByApiKey(String apiKeyString) {
-        if (apiKeyString == null || apiKeyString.isBlank()) {
+    @Cacheable(cacheNames = CacheNames.API_KEY, key = "#apiKey")
+    public Optional<ApiKey> getActiveByApiKey(String apiKey) {
+        if (apiKey == null || apiKey.isBlank()) {
             return Optional.empty();
         }
 
-        ApiKey apiKey = apiKeyMapper.findActiveByApiKey(apiKeyString);
-        if (apiKey == null) {
+        ApiKey fullApiKey = apiKeyMapper.findActiveByApiKey(apiKey);
+        if (fullApiKey == null) {
             return Optional.empty();
         }
 
-        apiKey.setRoles(userPermissionMapper.findRolesByUserId(apiKey.getUserId()));
+        fullApiKey.setRoles(userPermissionMapper.findRolesByUserId(fullApiKey.getUserId()));
 
-        return Optional.of(apiKey);
+        return Optional.of(fullApiKey);
     }
 
     public void create(Integer userId, String name) {
-        apiKeyMapper.insert(userId, generateKey(), name);
+        String apiKey = idGenerator.generateRandomString(32);
+
+        apiKeyMapper.insert(userId, apiKey, name);
     }
 
-    public void deleteApiKey(ApiKey apiKey) {
-        removeActiveApiKeyFromCache(apiKey);
-        apiKeyMapper.deleteById(apiKey);
-    }
-
-    public void removeActiveApiKeysFromCache(Integer userId) {
-        getByUserId(userId).forEach(this::removeActiveApiKeyFromCache);
-    }
-
-    private void removeActiveApiKeyFromCache(ApiKey apiKey) {
-        Cache cache = cacheManager.getCache(CACHE_ACTIVE_API_KEYS);
-        if (cache == null) {
-            return;
-        }
-
-        cache.evict(apiKey.getApiKey());
-    }
-
-    private String generateKey() {
-        return idGenerator.generateRandomString(32);
+    @CacheEvict(cacheNames = CacheNames.API_KEY, key = "#fullApiKey.apiKey")
+    public void deleteApiKey(ApiKey fullApiKey) {
+        apiKeyMapper.deleteById(fullApiKey);
     }
 }

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/auth/UserService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/auth/UserService.java
@@ -1,9 +1,6 @@
 package de.sustineo.simdesk.services.auth;
 
-import de.sustineo.simdesk.entities.auth.User;
-import de.sustineo.simdesk.entities.auth.UserPermission;
-import de.sustineo.simdesk.entities.auth.UserRole;
-import de.sustineo.simdesk.entities.auth.UserType;
+import de.sustineo.simdesk.entities.auth.*;
 import de.sustineo.simdesk.mybatis.mapper.UserMapper;
 import de.sustineo.simdesk.mybatis.mapper.UserPermissionMapper;
 import de.sustineo.simdesk.mybatis.mapper.UserRoleMapper;
@@ -65,7 +62,9 @@ public class UserService {
             userPermissionMapper.insert(userPermission);
         }
 
-        apiKeyService.removeActiveApiKeysFromCache(user.getId());
+        // Delete existing API keys of the user
+        List<ApiKey> apiKeys = apiKeyService.getByUserId(user.getId());
+        apiKeys.forEach(apiKeyService::deleteApiKey);
     }
 
     public Set<? extends GrantedAuthority> getAuthoritiesByUserId(Integer userId) {

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/bop/BopService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/bop/BopService.java
@@ -1,5 +1,6 @@
 package de.sustineo.simdesk.services.bop;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.configuration.ProfileManager;
 import de.sustineo.simdesk.entities.Setting;
 import de.sustineo.simdesk.entities.Track;
@@ -60,22 +61,22 @@ public class BopService {
         });
     }
 
-    @Cacheable("bops")
+    @Cacheable(cacheNames = CacheNames.BOPS, key = "'all'")
     public List<Bop> getAll() {
         return bopMapper.findAll();
     }
 
-    @Cacheable("bops-active")
+    @Cacheable(cacheNames = CacheNames.BOPS, key = "'active'")
     public List<Bop> getActive() {
         return bopMapper.findActive();
     }
 
-    @CacheEvict(value = {"bops", "bops-active"}, allEntries = true)
+    @CacheEvict(cacheNames = CacheNames.BOPS, allEntries = true)
     public void insert(Bop bop) {
         bopMapper.insert(bop);
     }
 
-    @CacheEvict(value = {"bops", "bops-active"}, allEntries = true)
+    @CacheEvict(cacheNames = CacheNames.BOPS, allEntries = true)
     public void update(Bop bop) {
         if (bop.getTrackId() == null || bop.getCarId() == null) {
             return;
@@ -93,7 +94,7 @@ public class BopService {
                 .build();
     }
 
-    @Cacheable("bop-providers")
+    @Cacheable(cacheNames = CacheNames.BOP_PROVIDERS)
     public Set<BopProvider> getBopProviders() {
         BopProvider[] bopProviders = settingService.getJson(Setting.BOP_PROVIDERS, BopProvider[].class);
         if (bopProviders == null) {
@@ -103,7 +104,7 @@ public class BopService {
         return Set.of(bopProviders);
     }
 
-    @CacheEvict(value = "bop-providers", allEntries = true)
+    @CacheEvict(cacheNames = CacheNames.BOP_PROVIDERS, allEntries = true)
     public void setBopProviders(Collection<BopProvider> bopProviders) {
         settingService.setJson(Setting.BOP_PROVIDERS, bopProviders.toArray(BopProvider[]::new));
     }

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/DriverService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/DriverService.java
@@ -3,6 +3,7 @@ package de.sustineo.simdesk.services.leaderboard;
 import de.sustineo.simdesk.configuration.ProfileManager;
 import de.sustineo.simdesk.entities.Driver;
 import de.sustineo.simdesk.mybatis.mapper.DriverMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -10,31 +11,28 @@ import java.util.List;
 
 @Profile(ProfileManager.PROFILE_LEADERBOARD)
 @Service
+@RequiredArgsConstructor
 public class DriverService {
     private final DriverMapper driverMapper;
 
-    public DriverService(DriverMapper driverMapper) {
-        this.driverMapper = driverMapper;
-    }
-
-    public void upsertDriver(Driver driver) {
-        driverMapper.upsert(driver);
+    public Driver getDriverById(String driverId) {
+        return driverMapper.findById(driverId);
     }
 
     public List<Driver> getAllDrivers() {
         return driverMapper.findAll();
     }
 
-    public void updateDriverVisibility(Driver driver) {
-        driverMapper.updateVisibility(driver);
-    }
-
     public List<String> getDriverIdsBySessionIdAndCarId(Integer id, Integer carId) {
         return driverMapper.findDriverIdsBySessionIdAndCarId(id, carId);
     }
 
-    public Driver getDriverById(String driverId) {
-        return driverMapper.findById(driverId);
+    public void upsertDriver(Driver driver) {
+        driverMapper.upsert(driver);
+    }
+
+    public void updateDriverVisibility(Driver driver) {
+        driverMapper.updateVisibility(driver);
     }
 }
 

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/LapService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/LapService.java
@@ -1,5 +1,6 @@
 package de.sustineo.simdesk.services.leaderboard;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.configuration.ProfileManager;
 import de.sustineo.simdesk.entities.FileMetadata;
 import de.sustineo.simdesk.entities.Lap;
@@ -9,6 +10,10 @@ import de.sustineo.simdesk.mybatis.mapper.LapMapper;
 import de.sustineo.simdesk.services.converter.LapConverter;
 import lombok.extern.java.Log;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,42 +24,50 @@ import java.util.List;
 @Log
 @Service
 public class LapService {
-    private final DriverService driverService;
+    private final LapService self;
     private final LapConverter lapConverter;
     private final LapMapper lapMapper;
+    private final DriverService driverService;
 
     @Autowired
-    public LapService(DriverService driverService, LapMapper lapMapper, LapConverter lapConverter) {
-        this.driverService = driverService;
+    public LapService(@Lazy LapService lapService,
+                      LapMapper lapMapper,
+                      LapConverter lapConverter,
+                      DriverService driverService) {
+        this.self = lapService;
         this.lapMapper = lapMapper;
         this.lapConverter = lapConverter;
+        this.driverService = driverService;
     }
 
     @Transactional
     public void processLaps(Session session, AccSession accSession, FileMetadata fileMetadata) {
         List<Lap> laps = lapConverter.convertToLaps(session, accSession, fileMetadata);
-        laps.forEach(this::insertLap);
+        laps.forEach(self::insertLap);
     }
 
-    @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheNames.LAPS_SESSION, key = "#lap.sessionId", condition = "#lap.sessionId != null"),
+            @CacheEvict(cacheNames = CacheNames.LAPS_DRIVER, key = "#lap.driver.id", condition = "#lap.driver?.id != null"),
+    })
     public void insertLap(Lap lap) {
         driverService.upsertDriver(lap.getDriver());
         lapMapper.insert(lap);
     }
 
-    public List<Lap> getBySessionIdAndDriverIds(Integer sessionId, List<String> driverIds) {
-        return lapMapper.findBySessionIdAndDriverIds(sessionId, driverIds);
-    }
-
-    public List<Lap> getBySessionIdAndDriverId(Integer sessionId, String driverId) {
-        return getBySessionIdAndDriverIds(sessionId, List.of(driverId));
-    }
-
+    @Cacheable(cacheNames = CacheNames.LAPS_SESSION, key = "#sessionId")
     public List<Lap> getBySessionId(Integer sessionId) {
         return lapMapper.findBySessionId(sessionId);
     }
 
+    @Cacheable(cacheNames = CacheNames.LAPS_DRIVER, key = "#driverId")
     public List<Lap> getByDriverId(String driverId) {
         return lapMapper.findByDriverId(driverId);
+    }
+
+    public List<Lap> getBySessionIdAndDriverIds(Integer sessionId, List<String> driverIds) {
+        return self.getBySessionId(sessionId).stream()
+                .filter(lap -> lap.getDriver() != null && driverIds.contains(lap.getDriver().getId()))
+                .toList();
     }
 }

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/LeaderboardService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/LeaderboardService.java
@@ -1,5 +1,6 @@
 package de.sustineo.simdesk.services.leaderboard;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.configuration.ProfileManager;
 import de.sustineo.simdesk.entities.Driver;
 import de.sustineo.simdesk.entities.FileMetadata;
@@ -8,6 +9,9 @@ import de.sustineo.simdesk.entities.Session;
 import de.sustineo.simdesk.entities.json.kunos.acc.AccSession;
 import de.sustineo.simdesk.mybatis.mapper.LeaderboardMapper;
 import de.sustineo.simdesk.services.converter.LeaderboardConverter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,33 +20,28 @@ import java.util.List;
 
 @Profile(ProfileManager.PROFILE_LEADERBOARD)
 @Service
+@RequiredArgsConstructor
 public class LeaderboardService {
     private final LeaderboardConverter leaderboardConverter;
     private final LeaderboardMapper leaderboardMapper;
     private final DriverService driverService;
 
-    public LeaderboardService(LeaderboardConverter leaderboardConverter, DriverService driverService, LeaderboardMapper leaderboardMapper) {
-        this.leaderboardConverter = leaderboardConverter;
-        this.driverService = driverService;
-        this.leaderboardMapper = leaderboardMapper;
-    }
-
     @Transactional
+    @CacheEvict(cacheNames = CacheNames.LEADERBOARD_LINES, key = "#session.id")
     public void processLeaderboardLines(Session session, AccSession accSession, FileMetadata fileMetadata) {
         List<LeaderboardLine> leaderboardLines = leaderboardConverter.convertToLeaderboardLines(session, accSession, fileMetadata);
-        leaderboardLines.forEach(leaderboardLine -> insertLeaderboardLine(session.getId(), leaderboardLine));
-    }
 
-    @Transactional
-    protected void insertLeaderboardLine(Integer sessionId, LeaderboardLine leaderboardLine) {
-        for (Driver driver : leaderboardLine.getDrivers()) {
-            driverService.upsertDriver(driver);
-            leaderboardMapper.insertLeaderboardDriver(sessionId, leaderboardLine.getCarId(), driver.getId(), driver.getDriveTimeMillis());
+        for (LeaderboardLine leaderboardLine : leaderboardLines) {
+            for (Driver driver : leaderboardLine.getDrivers()) {
+                driverService.upsertDriver(driver);
+                leaderboardMapper.insertLeaderboardDriver(session.getId(), leaderboardLine.getCarId(), driver.getId(), driver.getDriveTimeMillis());
+            }
+
+            leaderboardMapper.insertLeaderboardLine(leaderboardLine);
         }
-
-        leaderboardMapper.insertLeaderboardLine(leaderboardLine);
     }
 
+    @Cacheable(cacheNames = CacheNames.LEADERBOARD_LINES, key = "#sessionId")
     public List<LeaderboardLine> getLeaderboardLinesBySessionId(Integer sessionId) {
         return leaderboardMapper.findBySessionIdOrderByRanking(sessionId);
     }

--- a/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/RankingService.java
+++ b/simdesk-web/src/main/java/de/sustineo/simdesk/services/leaderboard/RankingService.java
@@ -1,5 +1,6 @@
 package de.sustineo.simdesk.services.leaderboard;
 
+import de.sustineo.simdesk.configuration.CacheNames;
 import de.sustineo.simdesk.configuration.ProfileManager;
 import de.sustineo.simdesk.entities.CarGroup;
 import de.sustineo.simdesk.entities.comparator.DriverRankingComparator;
@@ -13,6 +14,7 @@ import de.sustineo.simdesk.views.enums.TimeRange;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -31,12 +33,14 @@ public class RankingService {
     private final RankingMapper rankingMapper;
     private final Executor taskExecutor;
 
+    @Cacheable(cacheNames = CacheNames.RANKINGS)
     public List<GroupRanking> getAllTimeGroupRanking(TimeRange timeRange) {
         return rankingMapper.findAllTimeFastestLaps(timeRange.from(), timeRange.to()).stream()
                 .sorted(new GroupRankingComparator())
                 .toList();
     }
 
+    @Cacheable(cacheNames = CacheNames.RANKINGS)
     public List<DriverRanking> getAllTimeDriverRanking(@Nonnull CarGroup carGroup, @Nonnull String trackId, @Nonnull TimeRange timeRange, @Nullable AccCar car) {
         AtomicInteger ranking = new AtomicInteger(1);
 

--- a/simdesk-web/src/main/resources/application.yaml
+++ b/simdesk-web/src/main/resources/application.yaml
@@ -22,6 +22,8 @@ spring:
       write-dates-as-timestamps: false
     mapper:
       propagate-transient-marker: true
+  cache:
+    type: caffeine
   servlet:
     multipart:
       max-file-size: 10MB
@@ -37,16 +39,13 @@ management:
   endpoints:
     web:
       exposure:
-        include: "info,health,prometheus"
+        include: info, health, caches, metrics, prometheus
     access:
-      default: none
-  endpoint:
-    health:
-      access: read_only
-    info:
-      access: read_only
-    prometheus:
-      access: read_only
+      default: read_only
+  metrics:
+    enable:
+      spring.security: false
+      http.server.requests: false
 logging:
   level:
     root: INFO


### PR DESCRIPTION
This pull request introduces a new centralized caching configuration using Caffeine, refactors cache usage across multiple services to utilize named constants, and adds new dependencies for caching and metrics. It also makes minor improvements to security configuration, adjusts the `.gitignore` for development artifacts, and performs some code clean-up and reorganization.

Caching infrastructure and usage:

* Added a new `CacheConfiguration` class that configures a global Caffeine cache manager with custom weigher and expiration settings, and introduced a `CacheNames` class to centralize cache name constants. [[1]](diffhunk://#diff-40f9ef3c500c1d04d44e0b2e59a1c8f608c337438eed8f332f6bd87e66dac5c7R1-R49) [[2]](diffhunk://#diff-8b26e3bbf0aa184da82d5dfb3ba9f74d3ac75272cedb04ea12c7853de734c44eR1-R31)
* Refactored all cache annotations in services (`ApiKeyService`, `SettingService`, `BopService`) to use the new `CacheNames` constants, improving maintainability and consistency. [[1]](diffhunk://#diff-ff1f5ea5332388475daa47202e8cd6568b1bcb2437e42cb43cefd87109ef4f2aR3-R9) [[2]](diffhunk://#diff-ff1f5ea5332388475daa47202e8cd6568b1bcb2437e42cb43cefd87109ef4f2aL19-R49) [[3]](diffhunk://#diff-cf9ab05dd9ec7c20e1be9624b02610efccf26fb75c289c899646cb27415d22d1R3) [[4]](diffhunk://#diff-cf9ab05dd9ec7c20e1be9624b02610efccf26fb75c289c899646cb27415d22d1L16-R17) [[5]](diffhunk://#diff-cf9ab05dd9ec7c20e1be9624b02610efccf26fb75c289c899646cb27415d22d1L26-R27) [[6]](diffhunk://#diff-cf9ab05dd9ec7c20e1be9624b02610efccf26fb75c289c899646cb27415d22d1L36-R42) [[7]](diffhunk://#diff-fa2ed332131f2617c705ffb2d02952c1fb563048bdaddc1975494087b1f8a246R3) [[8]](diffhunk://#diff-fa2ed332131f2617c705ffb2d02952c1fb563048bdaddc1975494087b1f8a246L63-R79) [[9]](diffhunk://#diff-fa2ed332131f2617c705ffb2d02952c1fb563048bdaddc1975494087b1f8a246L96-R97) [[10]](diffhunk://#diff-fa2ed332131f2617c705ffb2d02952c1fb563048bdaddc1975494087b1f8a246L106-R107) [[11]](diffhunk://#diff-7d37a115cd42654f3a210695d4066ac4c387c0c7ff58eb59cf7dcf3060804577R3)
* Reworked API key cache eviction logic to use `@CacheEvict` and removed manual cache handling in `ApiKeyService`. [[1]](diffhunk://#diff-ff1f5ea5332388475daa47202e8cd6568b1bcb2437e42cb43cefd87109ef4f2aL19-R49) [[2]](diffhunk://#diff-58b50c2eda5f433aaf87a8ec394ad5f23ec7845c728e031065c6814691692c4fL68-R67)

Dependency and configuration updates:

* Added Caffeine and Micrometer Prometheus registry dependencies to `build.gradle` for caching and metrics support.
* Changed the default theme in the development run configuration to `BLACK_AND_WHITE`.
* Updated `.gitignore` to exclude the `results/` directory and removed redundant `.gitignore` entries. [[1]](diffhunk://#diff-8d840c858707e6782561127717994df99a11d62ee49d681d8eecb8b8a5fe5d47R1) [[2]](diffhunk://#diff-9f993c10ad177a8424ac6b3eb6f4f29c26a26cd3638b4f1dc050152dfbc2f34fL1-L2)

Security and access control:

* Improved actuator endpoint security: `/actuator/health` is now public, but all other `/actuator/**` endpoints require admin role. [[1]](diffhunk://#diff-fd9644c1a8ee49dc24eb5ba43ac50b7de97d1bdaa049cb6fdee326dd96fc36abL46-R53) [[2]](diffhunk://#diff-fd9644c1a8ee49dc24eb5ba43ac50b7de97d1bdaa049cb6fdee326dd96fc36abR79)
* Added clarifying comments to public path definitions and imported `UserRoleEnum` in `SecurityConfiguration`.

Code cleanup and minor fixes:

* Cleaned up and reorganized `DriverService` for clarity and used Lombok's `@RequiredArgsConstructor`.
* Updated method calls and removed unused MyBatis mapper method in `LapMapper`. [[1]](diffhunk://#diff-27aa4678667011ae1b0991e5a2f8310b48173b4a2e5597e9656e58e24b483140L68-R68) [[2]](diffhunk://#diff-b5b77b689200f0d577fb2b757d41f7c9fc89991cd78fb9e51b940b39bc006f54L28-L42)
* Minor import optimizations and code formatting in several service classes. [[1]](diffhunk://#diff-58b50c2eda5f433aaf87a8ec394ad5f23ec7845c728e031065c6814691692c4fL3-R3) [[2]](diffhunk://#diff-fa2ed332131f2617c705ffb2d02952c1fb563048bdaddc1975494087b1f8a246R3) [[3]](diffhunk://#diff-7d37a115cd42654f3a210695d4066ac4c387c0c7ff58eb59cf7dcf3060804577R3)